### PR TITLE
Add static uploads directory in app_server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log
 # Mac / system
 .DS_Store
 uploads/
+!app_server/uploads/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ project-root/
 │           └── endpoints/
 │               ├── file.py      # 파일 업로드, 다운로드 API
 │               └── quiz.py      # 퀴즈 생성, 채점 API
+│   └── uploads/             # 업로드된 파일 저장 폴더
 ├── core/
 │   └── database.py          # SQLAlchemy + get_db
 ├── models/
@@ -41,7 +42,6 @@ project-root/
 │       ├── ppt_extractor.py
 │       ├── txt_extractor.py
 │       └── hwp_extractor.py
-├── uploads/                 # 업로드된 파일 저장 폴더
 ├── .env
 ├── requirements.txt
 └── README.md

--- a/app_server/api/v1/endpoints/file.py
+++ b/app_server/api/v1/endpoints/file.py
@@ -8,9 +8,9 @@ from app_server.core.database import get_db
 from app_server.models.file import UploadedFile
 from app_server.services.file_service import extract_text
 
-ROOT_DIR = Path(__file__).resolve().parents[4]
-UPLOAD_DIR = ROOT_DIR / "uploads"
-UPLOAD_DIR.mkdir(exist_ok=True)
+# Define the uploads directory inside ``app_server``.
+APP_DIR = Path(__file__).resolve().parents[3]
+UPLOAD_DIR = APP_DIR / "uploads"
 
 router = APIRouter()
 

--- a/app_server/services/quiz_service.py
+++ b/app_server/services/quiz_service.py
@@ -6,9 +6,8 @@ from app_server.services.gpt_client import generate_quiz_from_text
 from app_server.services.file_service import extract_text
 
 # uploads 폴더 경로
-ROOT_DIR = Path(__file__).resolve().parents[2]
-UPLOAD_DIR = ROOT_DIR / "uploads"
-UPLOAD_DIR.mkdir(exist_ok=True)
+APP_DIR = Path(__file__).resolve().parents[1]
+UPLOAD_DIR = APP_DIR / "uploads"
 
 
 def generate_quiz(pid: str, db):


### PR DESCRIPTION
## Summary
- add persistent uploads folder inside `app_server`
- point upload path references to `app_server/uploads`
- document new uploads folder location
- update gitignore so this folder is tracked

## Testing
- `python3 -m py_compile app_server/api/v1/endpoints/file.py app_server/services/quiz_service.py`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478e150df08320a450d6830364cbac