### PR TITLE
Add API v2 endpoints

### DIFF
--- a/app_server/api/v2/endpoints/file.py
+++ b/app_server/api/v2/endpoints/file.py
@@ -1,0 +1,64 @@
+from fastapi import APIRouter, UploadFile, File, Form, Depends, HTTPException
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+from pathlib import Path
+import os, uuid
+
+from app_server.core.database import get_db
+from app_server.models.file import UploadedFile
+from app_server.services.file_service import extract_text
+
+# Define the uploads directory inside ``app_server``.
+APP_DIR = Path(__file__).resolve().parents[3]
+UPLOAD_DIR = APP_DIR / "uploads"
+
+router = APIRouter()
+
+@router.post("/upload/")
+async def upload_file(
+    lecture_name: str = Form(...),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db)
+):
+    unique_filename = f"{uuid.uuid4().hex}_{file.filename}"
+    file_path = os.path.join(UPLOAD_DIR, unique_filename)
+    with open(file_path, "wb") as f:
+        f.write(await file.read())
+
+    extracted = extract_text(file_path)
+    if not extracted:
+        raise HTTPException(status_code=400, detail="텍스트 추출 실패")
+
+    db_file = UploadedFile(
+        filename=unique_filename,
+        lecture_name=lecture_name,
+        extracted_text=extracted
+    )
+    db.add(db_file)
+    db.commit()
+    db.refresh(db_file)
+
+    return {
+        "file_id": db_file.id,
+        "filename": unique_filename,
+        "text": extracted,
+        "message": "업로드 및 저장 완료"
+    }
+
+@router.get("/file/{filename}")
+async def get_file(filename: str):
+    file_path = os.path.join(UPLOAD_DIR, filename)
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="파일이 존재하지 않습니다")
+    return FileResponse(file_path)
+
+@router.post("/text/")
+async def save_text(pid: str = Form(...), text: str = Form(...)):
+    """Save raw text to a file associated with the given pid."""
+    filename = f"{pid}.txt"
+    file_path = UPLOAD_DIR / filename
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(text)
+    return {"pid": pid, "message": "저장 완료"}
+
+

--- a/app_server/api/v2/endpoints/quiz.py
+++ b/app_server/api/v2/endpoints/quiz.py
@@ -1,0 +1,27 @@
+# app_server/api/v1/endpoints/quiz.py
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy.orm import Session
+from fastapi import Depends
+
+from app_server.schemas import QuizRequest, QuizSubmission
+from app_server.services.quiz_service import generate_quiz, grade_quiz
+from app_server.core.database import get_db
+
+router = APIRouter()
+
+@router.post("/generate")
+async def create_quiz(request: QuizRequest, db: Session = Depends(get_db)):
+    try:
+        quiz = generate_quiz(request.pid, db)
+        return quiz
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    
+@router.post("/submit")
+async def submit_quiz(submission: QuizSubmission, db: Session = Depends(get_db)):
+    try:
+        result = grade_quiz(submission.quiz_id, submission.answers, db)
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app_server/main.py
+++ b/app_server/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app_server.api.v1.endpoints import file, quiz
+from app_server.api.v2.endpoints import file, quiz
 from app_server.core.database import Base, engine
 
 # FastAPI 인스턴스 생성 + Swagger 정보 설정
@@ -23,5 +23,5 @@ app.add_middleware(
 Base.metadata.create_all(bind=engine)
 
 # 라우터 등록
-app.include_router(file.router, prefix="/api/v1", tags=["File"])
-app.include_router(quiz.router, prefix="/api/v1", tags=["Quiz"])
+app.include_router(file.router, prefix="/api/v2", tags=["File"])
+app.include_router(quiz.router, prefix="/api/v2", tags=["Quiz"])

--- a/app_ui/pages/FileList.jsx
+++ b/app_ui/pages/FileList.jsx
@@ -30,7 +30,7 @@ export default function FileList() {
     //뷰어구현
     setIsLoading(true);
     try {
-      const response = await fetch(`http://3.148.139.172:8000/api/v1/file/${filename}`);
+      const response = await fetch(`http://3.148.139.172:8000/api/v2/file/${filename}`);
       if (!response.ok) throw new Error('파일 불러오기에 실패했습니다.');
 
       const blob = await response.blob();

--- a/app_ui/pages/quiz.jsx
+++ b/app_ui/pages/quiz.jsx
@@ -29,7 +29,7 @@ export default function QuizPage() {
       const startTime = Date.now();
 
       try {
-        const res = await fetch(`http://3.148.139.172:8000/api/v1/generate/`);
+        const res = await fetch(`http://3.148.139.172:8000/api/v2/generate/`);
         if (!res.ok) throw new Error('퀴즈 데이터를 불러올 수 없습니다');
         const data = await res.json();
 

--- a/app_ui/utils/api.js
+++ b/app_ui/utils/api.js
@@ -2,7 +2,7 @@
 // utils/api.js
 
 export async function uploadFile(formData) {
-  const res = await fetch('http://3.148.139.172:8000/api/v1/upload/', {
+  const res = await fetch('http://3.148.139.172:8000/api/v2/upload/', {
     method: 'POST',
     body: formData,
   });


### PR DESCRIPTION
## Summary
- duplicate v1 endpoints into `api/v2/endpoints`
- update FastAPI imports and router prefixes to use v2
- point UI fetch calls to `/api/v2/`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint --silent` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478fea56748320bd19d920b30ed076