### PR TITLE
Fix default landing page

### DIFF
--- a/app_ui/pages/index.jsx
+++ b/app_ui/pages/index.jsx
@@ -1,10 +1,10 @@
 //메인 페이지 렌더링
-import FileList from '../pages/FileList.jsx';
+import Main from '../pages/main.jsx';
 
 export default function Home() {
   return (
     <main>
-      <FileList /> {/*main.jsx파일 내용 가져오기*/}
+      <Main /> {/*main.jsx파일 내용 가져오기*/}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- revert the index page to render `main.jsx`

## Testing
- `npm run build` *(fails: next: not found)*
- `npm run start` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684791523b7c83208690f08b20ab1abd