### PR TITLE
Handle new quiz API shape

### DIFF
--- a/app_ui/components/QuizUI.jsx
+++ b/app_ui/components/QuizUI.jsx
@@ -14,11 +14,16 @@ export default function QuizUI({ quizData }) {
   const [feedbackImage, setFeedbackImage] = useState(null);
 
   /*유효성 검사 조건문*/
-  if (!quizData) {
+  if (!quizData || !quizData.question) {
     return <div>퀴즈 데이터를 불러오는 중입니다...</div>;
   }
 
-  const { filename, question, options, explanations } = quizData;
+  const {
+    filename,
+    question,
+    options = [],
+    explanations = [],
+  } = quizData;
 
   const handleSelect = (idx) => {
     if (graded) return; // 채점 후에는 다른 보기 선택 불가
@@ -30,7 +35,7 @@ export default function QuizUI({ quizData }) {
       setGraded(false);
       setSelected(null);
       setExplanationIndex(null);
-    } else if (selected !== null) {
+    } else if (selected !== null && options.length > 0) {
       setGraded(true);
       setExplanationIndex(selected);
 
@@ -60,24 +65,28 @@ export default function QuizUI({ quizData }) {
         <div className={styles.questionBox}>{question}</div>
 
         <div className={styles.options}>
-          {options.map((opt, idx) => {
-            const isSelected = selected === idx;
-            const isCorrect = graded && selected === idx && opt.is_correct;
-            const isWrong = graded && isSelected && !opt.is_correct;
+          {options.length === 0 ? (
+            <div className={styles.noOptions}>보기 문항이 없습니다.</div>
+          ) : (
+            options.map((opt, idx) => {
+              const isSelected = selected === idx;
+              const isCorrect = graded && selected === idx && opt.is_correct;
+              const isWrong = graded && isSelected && !opt.is_correct;
 
-            return (
-              <div
-                key={idx}
-                className={`${styles.option} 
-                  ${isSelected ? styles.selected : ''} 
-                  ${isCorrect ? styles.correct : ''} 
-                  ${isWrong ? styles.incorrect : ''}`}
-                onClick={() => handleSelect(idx)}
-              >
-                {`${idx + 1}. ${opt.text}`}
-              </div>
-            );
-          })}
+              return (
+                <div
+                  key={idx}
+                  className={`${styles.option}
+                    ${isSelected ? styles.selected : ''}
+                    ${isCorrect ? styles.correct : ''}
+                    ${isWrong ? styles.incorrect : ''}`}
+                  onClick={() => handleSelect(idx)}
+                >
+                  {`${idx + 1}. ${opt.text}`}
+                </div>
+              );
+            })
+          )}
         </div>
 
         <button className={styles.button} onClick={handleGrade}>

--- a/app_ui/pages/quiz.jsx
+++ b/app_ui/pages/quiz.jsx
@@ -10,6 +10,7 @@ import styles from '../styles/quiz.module.css';
 export default function QuizPage() {
   const searchParams = useSearchParams();
   const fileId = searchParams.get('id'); // URL에서 ?id=.. 가져오기
+  const fileName = searchParams.get('file');
 
   const [quizData, setQuizData] = useState(null);
   const [loadingIndex, setLoadingIndex] = useState(1);
@@ -38,11 +39,27 @@ export default function QuizPage() {
         if (!res.ok) throw new Error('퀴즈 데이터를 불러올 수 없습니다');
         const data = await res.json();
 
+        let transformed = data;
+        if (data && data.questions && data.questions.length > 0) {
+          const q = data.questions[0];
+          transformed = {
+            filename: fileName,
+            question: q.question,
+            options: Array.isArray(q.options)
+              ? q.options.map((opt, idx) => ({
+                  text: opt,
+                  is_correct: idx + 1 === q.answer,
+                }))
+              : [],
+            explanations: q.explanations || [],
+          };
+        }
+
         const elapsed = Date.now() - startTime;
         const remaining = 5000 - elapsed; // 최소 5초 유지
 
         setTimeout(() => {
-          setQuizData(data);
+          setQuizData(transformed);
           setShowLoading(false);
         }, remaining > 0 ? remaining : 0);
       } catch (err) {

--- a/app_ui/styles/quiz.module.css
+++ b/app_ui/styles/quiz.module.css
@@ -153,6 +153,12 @@
   animation: fadeInOut 2s ease;
 }
 
+.noOptions {
+  text-align: center;
+  margin-bottom: 20px;
+  color: #666;
+}
+
 @keyframes fadeInOut {
   0% { opacity: 0; transform: scale(0.9); }
   20% { opacity: 1; transform: scale(1); }


### PR DESCRIPTION
## Summary
- transform `data.questions[0]` if present when loading quiz data
- keep filename from URL query and adapt to new field structure
- guard QuizUI against missing options and show message when none exist
- add a simple style for missing-options message

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492d9fa18c83209a5ba4037324d3c7