### PR TITLE
Fix quiz loading handling

### DIFF
--- a/app_server/api/v1/endpoints/quiz.py
+++ b/app_server/api/v1/endpoints/quiz.py
@@ -14,7 +14,7 @@ router = APIRouter()
 async def create_quiz(request: QuizRequest, db: Session = Depends(get_db)):
     try:
         quiz = generate_quiz(request.pid, db)
-        return quiz
+        return {"quiz": quiz}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     

--- a/app_server/api/v2/endpoints/quiz.py
+++ b/app_server/api/v2/endpoints/quiz.py
@@ -14,7 +14,7 @@ router = APIRouter()
 async def create_quiz(request: QuizRequest, db: Session = Depends(get_db)):
     try:
         quiz = generate_quiz(request.pid, db)
-        return quiz
+        return {"quiz": quiz}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     

--- a/app_ui/pages/quiz.jsx
+++ b/app_ui/pages/quiz.jsx
@@ -38,10 +38,11 @@ export default function QuizPage() {
         
         if (!res.ok) throw new Error('퀴즈 데이터를 불러올 수 없습니다');
         const data = await res.json();
+        const quiz = data.quiz;
 
-        let transformed = data;
-        if (data && data.questions && data.questions.length > 0) {
-          const q = data.questions[0];
+        let transformed = quiz;
+        if (quiz && quiz.questions && quiz.questions.length > 0) {
+          const q = quiz.questions[0];
           transformed = {
             filename: fileName,
             question: q.question,
@@ -85,7 +86,11 @@ export default function QuizPage() {
           />
         </div>
       ) : (
-        <QuizUI quizData={quizData} /> // props전달
+        quizData ? (
+          <QuizUI quizData={quizData} />
+        ) : (
+          <div>퀴즈를 불러오지 못했습니다.</div>
+        )
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap quiz creation endpoint response in `{"quiz": ...}`
- update Next.js quiz page to consume `data.quiz`
- add guard UI when quiz data fails to load

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_6849329ecf1c832087687cebf16ff589