### PR TITLE
Fix quiz data flow

### DIFF
--- a/app_server/services/quiz_service.py
+++ b/app_server/services/quiz_service.py
@@ -21,6 +21,10 @@ def generate_quiz(pid: str, db):
     # GPT로 퀴즈 생성
     quiz_data = generate_quiz_from_text(text)
 
+    # FastAPI가 일관된 형태의 JSON을 반환하도록 보정
+    if isinstance(quiz_data, dict) and "questions" in quiz_data:
+        return {"questions": quiz_data["questions"]}
+
     # TODO: 원하면 여기서 DB에 quiz_data 저장 가능
     return quiz_data
 

--- a/app_ui/components/QuizUI.jsx
+++ b/app_ui/components/QuizUI.jsx
@@ -13,9 +13,9 @@ export default function QuizUI({ quizData }) {
   const [explanationIndex, setExplanationIndex] = useState(null);
   const [feedbackImage, setFeedbackImage] = useState(null);
 
-  /*유효성 검사 조건문*/
+  /* 유효성 검사 - 필수 데이터가 없으면 렌더링하지 않음 */
   if (!quizData || !quizData.question) {
-    return <div>퀴즈 데이터를 불러오는 중입니다...</div>;
+    return <div>퀴즈 정보를 표시할 수 없습니다.</div>;
   }
 
   const {

--- a/app_ui/pages/quiz.jsx
+++ b/app_ui/pages/quiz.jsx
@@ -38,7 +38,7 @@ export default function QuizPage() {
         
         if (!res.ok) throw new Error('퀴즈 데이터를 불러올 수 없습니다');
         const data = await res.json();
-        const quiz = data.quiz;
+        const quiz = data.quiz || data; // "quiz" 키가 없을 때도 대비
 
         let transformed = quiz;
         if (quiz && quiz.questions && quiz.questions.length > 0) {


### PR DESCRIPTION
## Summary
- normalize quiz response in FastAPI service
- handle missing `quiz` key in React fetcher
- fail gracefully in `QuizUI`

## Testing
- `python3 -m py_compile app_server/services/quiz_service.py`
- `python3 -m py_compile app_server/api/v2/endpoints/quiz.py`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493788f3308320a81ba0d382d83232