### PR TITLE
Fix quiz generation to use DB stored text

### DIFF
--- a/app_server/services/quiz_service.py
+++ b/app_server/services/quiz_service.py
@@ -1,22 +1,16 @@
 # app_server/services/quiz_service.py
 
-from pathlib import Path
-
 from app_server.services.gpt_client import generate_quiz_from_text
-from app_server.services.file_service import extract_text
-
-# uploads 폴더 경로
-APP_DIR = Path(__file__).resolve().parents[1]
-UPLOAD_DIR = APP_DIR / "uploads"
+from app_server.models.file import UploadedFile
 
 
 def generate_quiz(pid: str, db):
     """Generate quiz for the text saved with the given pid."""
-    file_path = UPLOAD_DIR / f"{pid}.txt"
-    if not file_path.exists():
+    record = db.query(UploadedFile).filter(UploadedFile.id == int(pid)).first()
+    if not record:
         return {"error": "파일을 찾을 수 없습니다."}
 
-    text = extract_text(str(file_path))
+    text = record.extracted_text
 
     # GPT로 퀴즈 생성
     quiz_data = generate_quiz_from_text(text)


### PR DESCRIPTION
## Summary
- update quiz generation logic to read uploaded text from DB
- import `UploadedFile` model for DB lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493b3039e48320a57a935154a27d13