### PR TITLE
Remove unused comments and fix model exports

### DIFF
--- a/app_server/api/v1/endpoints/file.py
+++ b/app_server/api/v1/endpoints/file.py
@@ -8,7 +8,6 @@ from app_server.core.database import get_db
 from app_server.models.file import UploadedFile
 from app_server.services.file_service import extract_text
 
-# Define the uploads directory inside ``app_server``.
 APP_DIR = Path(__file__).resolve().parents[3]
 UPLOAD_DIR = APP_DIR / "uploads"
 

--- a/app_server/api/v1/endpoints/quiz.py
+++ b/app_server/api/v1/endpoints/quiz.py
@@ -1,5 +1,3 @@
-# app_server/api/v1/endpoints/quiz.py
-
 from fastapi import APIRouter, HTTPException
 from sqlalchemy.orm import Session
 from fastapi import Depends

--- a/app_server/api/v2/endpoints/file.py
+++ b/app_server/api/v2/endpoints/file.py
@@ -8,7 +8,6 @@ from app_server.core.database import get_db
 from app_server.models.file import UploadedFile
 from app_server.services.file_service import extract_text
 
-# Define the uploads directory inside ``app_server``.
 APP_DIR = Path(__file__).resolve().parents[3]
 UPLOAD_DIR = APP_DIR / "uploads"
 

--- a/app_server/api/v2/endpoints/quiz.py
+++ b/app_server/api/v2/endpoints/quiz.py
@@ -1,5 +1,3 @@
-# app_server/api/v1/endpoints/quiz.py
-
 from fastapi import APIRouter, HTTPException
 from sqlalchemy.orm import Session
 from fastapi import Depends

--- a/app_server/models/__init__.py
+++ b/app_server/models/__init__.py
@@ -1,4 +1,3 @@
 from .file import UploadedFile
-#from .quiz import Quiz  
 
-__all__ = ["UploadedFile", "Quiz"]
+__all__ = ["UploadedFile"]

--- a/app_server/schemas/quiz.py
+++ b/app_server/schemas/quiz.py
@@ -1,5 +1,3 @@
-# app_server/schemas/quiz.py
-
 from pydantic import BaseModel
 from typing import List
 

--- a/app_server/services/gpt_client.py
+++ b/app_server/services/gpt_client.py
@@ -1,5 +1,3 @@
-# app_server/services/gpt_client.py
-
 import os
 import json
 import traceback

--- a/app_server/services/quiz_service.py
+++ b/app_server/services/quiz_service.py
@@ -1,11 +1,8 @@
-# app_server/services/quiz_service.py
-
 from pathlib import Path
 
 from app_server.services.gpt_client import generate_quiz_from_text
 from app_server.services.file_service import extract_text
 
-# uploads 폴더 경로
 APP_DIR = Path(__file__).resolve().parents[1]
 UPLOAD_DIR = APP_DIR / "uploads"
 
@@ -18,15 +15,12 @@ def generate_quiz(pid: str, db):
 
     text = extract_text(str(file_path))
 
-    # GPT로 퀴즈 생성
     quiz_data = generate_quiz_from_text(text)
 
-    # TODO: 원하면 여기서 DB에 quiz_data 저장 가능
     return quiz_data
 
 
 def grade_quiz(quiz_id: str, answers: list[int], db):
-    # 현재는 고정된 정답 예시로 채점 (DB 연동 전 버전)
     correct_answers = [1, 2, 3]  # 나중에는 quiz_id 기반으로 DB에서 불러올 것
 
     if len(answers) != len(correct_answers):

--- a/app_ui/components/Footer.jsx
+++ b/app_ui/components/Footer.jsx
@@ -1,4 +1,3 @@
-// components/Footer.jsx
 import styles from '../styles/footer.module.css';
 
 export default function Footer() {

--- a/app_ui/components/QuizUI.jsx
+++ b/app_ui/components/QuizUI.jsx
@@ -1,5 +1,3 @@
-// QuizUI.jsx
-
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/app_ui/pages/_app.js
+++ b/app_ui/pages/_app.js
@@ -1,4 +1,3 @@
-// app-ui/pages/_app.js
 import '../styles/globals.css';
 import Layout from '../components/Layout';
 

--- a/app_ui/pages/_document.js
+++ b/app_ui/pages/_document.js
@@ -1,4 +1,3 @@
-// 위치: app-ui/pages/_document.js
 import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {

--- a/app_ui/pages/index.jsx
+++ b/app_ui/pages/index.jsx
@@ -1,10 +1,9 @@
-//메인 페이지 렌더링
 import Main from './main.jsx';
 
 export default function Home() {
   return (
     <main>
-      <Main /> {/*main.jsx파일 내용 가져오기*/}
+      <Main />
     </main>
   );
 }

--- a/app_ui/pages/quiz.jsx
+++ b/app_ui/pages/quiz.jsx
@@ -7,14 +7,12 @@ import styles from '../styles/quiz.module.css';
 
 export default function QuizPage() {
   const searchParams = useSearchParams();
-  // FileList에서 넘겨준 file_id
   const fileId = searchParams.get('file_id');
 
   const [quizData, setQuizData]         = useState(null);
   const [loadingIndex, setLoadingIndex] = useState(1);
   const [showLoading, setShowLoading]   = useState(true);
 
-  // 로딩 애니메이션 순환 (1,2,3 → 1…)
   useEffect(() => {
     const iv = setInterval(() => {
       setLoadingIndex(i => (i % 3) + 1);
@@ -22,7 +20,6 @@ export default function QuizPage() {
     return () => clearInterval(iv);
   }, []);
 
-  // file_id 유효성 검사 & 퀴즈 데이터 호출
   useEffect(() => {
     // file_id 없으면 곧바로 로딩 종료
     if (!fileId || fileId === 'null') {
@@ -41,7 +38,6 @@ export default function QuizPage() {
         const elapsed = Date.now() - startTime;
         const remaining = 5000 - elapsed;
 
-        // 최소 5초 로딩 유지
         setTimeout(() => {
           setQuizData(quiz);
           setShowLoading(false);
@@ -66,7 +62,6 @@ export default function QuizPage() {
           />
         </div>
       ) : quizData ? (
-        // QuizUI 쪽에서 URL의 filename 파라미터와 quizData.filename을 사용해 헤더를 표시하도록 구성
         <QuizUI quizData={quizData} />
       ) : (
         <div>퀴즈를 불러오지 못했습니다.</div>

--- a/app_ui/utils/api.js
+++ b/app_ui/utils/api.js
@@ -1,6 +1,3 @@
-// API 관련 fetch 로직 전담
-// utils/api.js
-
 export async function uploadFile(formData) {
   const res = await fetch('http://3.148.139.172:8000/api/v2/upload/', {
     method: 'POST',
@@ -11,5 +8,5 @@ export async function uploadFile(formData) {
     throw new Error('서버 업로드 실패');
   }
 
-  return await res.json(); // 반환된 데이터 구조: { filename, text, ... }
+  return await res.json();
 }


### PR DESCRIPTION
## Summary
- clean out leftover shell prompt in `models/__init__.py`
- remove path comments from API endpoints and services
- drop unneeded comments across frontend components
- run basic linting commands

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b130aa088320a2ce1ac79ad8aabe