### PR TITLE
Fix frontend issues and persistence

### DIFF
--- a/app_ui/components/FileUploader.jsx
+++ b/app_ui/components/FileUploader.jsx
@@ -29,23 +29,21 @@ export default function UploadModal({ onClose, onCreate }) {
       const formData = new FormData();
       formData.append('file', file);
       formData.append('lecture_name', name);
-      formData.append('description', desc);
 
       // uploadFile(formData) 호출 시 다음 형식의 응답을 기대합니다:
       // {
-      //   fileid: 123,
+      //   file_id: 123,
       //   filename: "uuid파일명.ext",
       //   text: "파일에서 추출된 텍스트",
       //   message: "업로드 및 저장 완료"
       // }
       const data = await uploadFile(formData);
 
-      // fileid → file_id로 매핑
       const newFolder = {
         name,
         description: desc,
         filename: data.filename,
-        file_id: data.fileid,
+        file_id: data.file_id,
         text: data.text,
       };
 

--- a/app_ui/pages/loading.jsx
+++ b/app_ui/pages/loading.jsx
@@ -17,7 +17,7 @@ export default function LoadingPage() {
     return () => clearInterval(imgTimer);
   }, []);
 
-  // file_id 기반 퀴즈 데이터 호출 + 3초 후 이동
+  // file_id 기반 퀴즈 데이터 호출 후 이동
   useEffect(() => {
     if (!file_id) return;
 
@@ -32,10 +32,10 @@ export default function LoadingPage() {
         // sessionStorage에 quiz 데이터 저장
         sessionStorage.setItem('quizData', JSON.stringify(quiz));
 
-        // 3초 로딩 후 quiz 페이지로 이동
+        // 짧은 로딩 후 quiz 페이지로 이동
         setTimeout(() => {
           router.push(`/quiz?file_id=${file_id}&filename=${filename}`);
-        }, 3000);
+        }, 1000);
       } catch (err) {
         console.error('LoadingPage fetch error:', err);
       }

--- a/app_ui/pages/main.jsx
+++ b/app_ui/pages/main.jsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import UploadModal from '../components/FileUploader';
 import styles from '../styles/main.module.css';
 import Footer from '../components/Footer';
@@ -8,6 +8,23 @@ export default function Main() {
   const [folders, setFolders] = useState([]);
   const [showModal, setShowModal] = useState(false);
   const router = useRouter();
+
+  // 로컬스토리지에서 폴더 정보 로드
+  useEffect(() => {
+    const stored = localStorage.getItem('folders');
+    if (stored) {
+      try {
+        setFolders(JSON.parse(stored));
+      } catch {
+        setFolders([]);
+      }
+    }
+  }, []);
+
+  // 폴더 목록이 변경될 때마다 저장
+  useEffect(() => {
+    localStorage.setItem('folders', JSON.stringify(folders));
+  }, [folders]);
 
   const goToFileList = (folder) => {
     const query = new URLSearchParams({

--- a/app_ui/pages/quiz.jsx
+++ b/app_ui/pages/quiz.jsx
@@ -7,17 +7,35 @@ import styles from '../styles/quiz.module.css';
 
 export default function QuizPage() {
   const router = useRouter();
-  const { filename } = router.query;
+  const { filename, file_id } = router.query;
 
   const [quizData, setQuizData] = useState(null);
 
-  // sessionStorage에서 quiz 데이터 가져오기
+  // sessionStorage에서 quiz 데이터 가져오기, 없으면 서버 요청
   useEffect(() => {
     const storedQuiz = sessionStorage.getItem('quizData');
     if (storedQuiz) {
       setQuizData(JSON.parse(storedQuiz));
+      return;
     }
-  }, []);
+
+    if (!file_id) return;
+
+    const fetchQuiz = async () => {
+      try {
+        const query = new URLSearchParams({ file_id }).toString();
+        const res = await fetch(`http://3.148.139.172:8000/api/v2/quiz?${query}`);
+        if (!res.ok) throw new Error();
+        const { quiz } = await res.json();
+        setQuizData(quiz);
+        sessionStorage.setItem('quizData', JSON.stringify(quiz));
+      } catch {
+        console.error('퀴즈 데이터를 불러올 수 없습니다.');
+      }
+    };
+
+    fetchQuiz();
+  }, [file_id]);
 
   return (
     <div className={styles.quizPageWrapper}>


### PR DESCRIPTION
## Summary
- fix `file_id` parsing in FileUploader and remove unused description upload
- persist created folders in localStorage
- shorten loading time and fetch quiz on reload

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b546439e08320bc77f4a505fb9486