### PR TITLE
Fix quiz endpoint URL

### DIFF
--- a/app_server/api/v2/endpoints/quiz.py
+++ b/app_server/api/v2/endpoints/quiz.py
@@ -34,7 +34,7 @@ async def submit_quiz(submission: QuizSubmission, db: Session = Depends(get_db))
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-@router.get("")
+@router.get("/quiz")
 async def get_quiz_by_file_id(file_id: int = Query(...), db: Session = Depends(get_db)):
     try:
         # file_id 기반으로 DB에서 조회


### PR DESCRIPTION
## Summary
- update quiz endpoint path

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688b61a8d2548320970ef682bec71c94